### PR TITLE
feat(gitignore): 添加智能 gitignore 检测和配置功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,19 @@
           "minimum": 10,
           "maximum": 500,
           "description": "%config.timeline.maxNodes.description%"
+        },
+        "recode.autoAddGitignore": {
+          "type": "boolean",
+          "default": true,
+          "description": "%config.autoAddGitignore.description%"
+        },
+        "recode.gitignoreVariants": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [".gitignore", ".gitignore_local", ".gitignore.local"],
+          "description": "%config.gitignoreVariants.description%"
         }
       }
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,5 +19,7 @@
   "config.protectedFileAction.confirm": "Require confirmation before recording",
   "command.showTimeline": "ReCode: Show Timeline",
   "config.timeline.enabled.description": "Enable timeline view feature",
-  "config.timeline.maxNodes.description": "Maximum number of nodes to display in timeline (10-500)"
+  "config.timeline.maxNodes.description": "Maximum number of nodes to display in timeline (10-500)",
+  "config.autoAddGitignore.description": "Automatically add .recode to .gitignore (checks global gitignore and configured variants first)",
+  "config.gitignoreVariants.description": "List of gitignore file variants to check (e.g., .gitignore, .gitignore_local)"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -19,5 +19,7 @@
   "config.protectedFileAction.confirm": "需要确认才记录",
   "command.showTimeline": "ReCode: 查看时间轴",
   "config.timeline.enabled.description": "启用时间轴视图功能",
-  "config.timeline.maxNodes.description": "时间轴最多显示的节点数 (10-500)"
+  "config.timeline.maxNodes.description": "时间轴最多显示的节点数 (10-500)",
+  "config.autoAddGitignore.description": "自动添加 .recode 到 .gitignore（优先检查全局 gitignore 和配置的变体文件）",
+  "config.gitignoreVariants.description": "要检查的 gitignore 文件变体列表（如 .gitignore、.gitignore_local）"
 }


### PR DESCRIPTION
## Summary

增强 `.recode` 自动添加到 `.gitignore` 的逻辑，添加多层检测机制和用户配置选项。

## Changes

### 新增检测逻辑（按优先级）

1. **全局 gitignore** - 检查 `git config --global core.excludesFile` 及默认路径
2. **仓库级 excludesFile** - 检查 `git config --local core.excludesFile`
3. **变体文件** - 检查配置的 gitignore 变体（默认：`.gitignore`, `.gitignore_local`, `.gitignore.local`）
4. **添加到仓库根目录** - 优先添加到 Git 仓库根目录而非工作区子目录

### 新增配置项

| 配置项 | 类型 | 默认值 | 描述 |
|--------|------|--------|------|
| `recode.autoAddGitignore` | boolean | `true` | 是否自动添加 .recode 到 gitignore |
| `recode.gitignoreVariants` | string[] | `[".gitignore", ".gitignore_local", ".gitignore.local"]` | 要检查的 gitignore 变体文件白名单 |

### 安全改进

- 使用 `execFile` 替代 `exec` 避免命令注入风险

## Testing

1. 在 VS Code 中按 F5 启动调试
2. 打开一个 Git 仓库
3. 验证以下场景：
   - 全局 gitignore 已有 `.recode` → 跳过添加
   - `.gitignore_local` 已有 `.recode` → 跳过添加
   - 设置 `recode.autoAddGitignore: false` → 禁用功能
   - 自定义 `recode.gitignoreVariants` → 使用自定义白名单